### PR TITLE
fix: iPhone Safari で検索候補が表示されない問題を修正 (#3)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1111,7 +1111,7 @@ document.addEventListener('DOMContentLoaded', () => {
   searchBtn.addEventListener('click', doSearch);
   locationInput.addEventListener('keydown', e => { if (e.key === 'Enter') doSearch(); });
   document.addEventListener('click', e => {
-    if (!searchResults.contains(e.target) && e.target !== locationInput) {
+    if (!searchResults.contains(e.target) && e.target !== locationInput && e.target !== searchBtn) {
       searchResults.classList.add('hidden');
     }
   });


### PR DESCRIPTION
検索ボタンのクリックイベントがdocumentまで伝播し、「外側クリック」と
誤判定されて候補パネルが即座に非表示になっていた。
searchBtn を除外条件に追加して修正。

https://claude.ai/code/session_01KsbDMh4r7VBHXmHcp5YHNA