### PR TITLE
fix: iPhone Safariでボタンが画面からはみ出る問題を修正 (#5)

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,7 @@ body {
   font-size: 15px;
   line-height: 1.6;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 /* ===== 設定ボタン ===== */
@@ -264,6 +265,7 @@ main {
 .search-box { display: flex; gap: 0.5rem; }
 .search-box input {
   flex: 1;
+  min-width: 0;
   background: var(--bg3);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -766,3 +768,27 @@ footer {
 /* ===== Leaflet overrides ===== */
 .leaflet-container { background: #1a1a2e; }
 .leaflet-tile { filter: brightness(0.8) saturate(0.6) hue-rotate(200deg); }
+
+/* ===== モバイル対応 (〜480px) ===== */
+@media (max-width: 480px) {
+  .input-panel { padding: 1rem 0.75rem; }
+
+  /* 場所ラベル行: ボタンが収まらない場合は折り返す */
+  .location-label-row {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .fav-list-btn {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.4rem;
+  }
+
+  /* 検索ボックス: ボタンのパディングを縮小 */
+  button#search-btn {
+    padding: 0.6rem 0.7rem;
+    font-size: 0.85rem;
+  }
+  .fav-add-btn {
+    padding: 0 0.4rem;
+  }
+}


### PR DESCRIPTION
- body に overflow-x: hidden を追加して横スクロールを防止
- .search-box input に min-width: 0 を追加しflexで正しく縮小できるよう修正
- @media (max-width: 480px) でモバイル向けパディングを最適化
  - .input-panel パディング縮小
  - 検索ボタン・fav-add-btnのパディング縮小
  - location-label-row に flex-wrap を追加

https://claude.ai/code/session_01KsbDMh4r7VBHXmHcp5YHNA